### PR TITLE
Ruby 1.9.2 compatibility

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,2 +1,12 @@
 require 'mkmf'
+
+case RUBY_VERSION
+when /\A1\.8/
+  $CFLAGS += ' -DRUBY_1_8_x'
+when /\A1\.9/
+  $CFLAGS += ' -DRUBY_1_9_x'
+else
+  raise "unsupported Ruby version: #{RUBY_VERSION}"
+end
+
 create_makefile('tuple')

--- a/ext/tuple.c
+++ b/ext/tuple.c
@@ -174,27 +174,6 @@ static VALUE empty_bignum(int sign, int len) {
 #error unsupported RUBY_VERSION
 #endif
 }
-// static VALUE empty_bignum(int sign, int len) {
-//   /* Create an empty bignum with the right number of digits. */
-//   NEWOBJ(num, struct RBignum);
-//   OBJSETUP(num, rb_cBignum, T_BIGNUM);
-// #if defined(RUBY_1_9_x)
-//   RBIGNUM_SET_SIGN(num, sign ? 1 : 0);
-//   // RBIGNUM_LEN(num) = len;
-//   // RBIGNUM_DIGITS(num) = ALLOC_N(BDIGIT, len);
-//   RBIGNUM(num)->len = len;
-//   num->digits = ALLOC_N(BDIGIT, len);
-// #elif defined(RUBY_1_8_x)
-//   num->sign = sign ? 1 : 0;
-//   num->len = len;
-//   num->digits = ALLOC_N(BDIGIT, len);
-// #else
-// #error unsupported RUBY_VERSION
-// #endif
-// 
-//   return (VALUE)num;
-// }
-
 
 static VALUE tuple_parse(void **data, int data_len) {
   VALUE tuple = rb_ary_new();


### PR DESCRIPTION
Hi Justin

I've been trying to get the BDB gem[1] working and found that it depends on Tuple, which I couldn't get to compile on Ruby 1.9.2. I've patched it with the help of a blog post I found[2], and the tests pass, so it seems to work :-)

Could you have a look at the changes and see if they make sense? I don't actually know anything about Ruby C extensions, so I may well have done something dumb in the process.

Cheers
Ash

[1] https://github.com/DenisKnauf/bdb
[2] https://wincent.com/wiki/Conditional_compilation_of_C_extensions_in_Ruby_1.9
